### PR TITLE
Adding relational database annotation

### DIFF
--- a/rse/client/annotate.py
+++ b/rse/client/annotate.py
@@ -9,6 +9,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
 
 from rse.main import Encyclopedia
+from rse.exceptions import RepoNotFoundError
 
 
 def main(args, extra):
@@ -17,10 +18,13 @@ def main(args, extra):
     enc = Encyclopedia(config_file=args.config_file)
 
     # The type is either criteria or taxonomy
-    enc.annotate(
-        username=args.username,
-        atype=args.type[0],
-        unseen_only=not args.all_repos,
-        repo=args.repo,
-        save=True,
-    )
+    try:
+        enc.annotate(
+            username=args.username,
+            atype=args.type[0],
+            unseen_only=not args.all_repos,
+            repo=args.repo,
+            save=True,
+        )
+    except RepoNotFoundError as exc:
+        print(exc)

--- a/rse/main/database/models.py
+++ b/rse/main/database/models.py
@@ -41,6 +41,16 @@ class SoftwareRepository(Base):
     def summary(self):
         return self.parser.summary()
 
+    @property
+    def url(self):
+        data = json.loads(self.data)
+        return self.parser.get_url(data)
+
+    @property
+    def description(self):
+        data = json.loads(self.data)
+        return self.parser.get_description(data)
+
     def load(self):
         """loading a software repository means exporting as json"""
         data = {"parser": self.parser_name, "uid": self.uid, "data": {}}
@@ -49,6 +59,26 @@ class SoftwareRepository(Base):
             data["data"] = json.loads(self.data)
 
         return data
+
+    def update_criteria(self, uid, username, response):
+        """Given a username and unique id update criteria"""
+        criteria = json.loads(self.criteria or "{}")
+
+        if uid not in criteria:
+            criteria[uid] = {}
+        if response:
+            criteria[uid][username] = "yes"
+        else:
+            criteria[uid][username] = "no"
+        self.criteria = json.dumps(criteria)
+
+    def update_taxonomy(self, username, uids):
+        """Given a username and unique id update taxonomy items"""
+        taxonomy = json.loads(self.taxonomy or "{}")
+
+        if username not in taxonomy:
+            taxonomy[username] = uids
+        self.taxonomy = json.dumps(taxonomy)
 
     def export(self):
         """Export removes the outer wrapper, and just returns the data"""

--- a/rse/utils/prompt.py
+++ b/rse/utils/prompt.py
@@ -45,7 +45,7 @@ def choice_prompt(prompt, choices, choice_prefix=None, multiple=False):
 
     if not choice_prefix:
         choice_prefix = "/".join(choices)
-    message = "Please enter your choice [%s] : " % (choice_prefix)
+    message = "[%s] : " % (choice_prefix)
 
     while choice not in choices:
         choice = get_input(message).strip()


### PR DESCRIPTION
This pull request will support annotation for relational databases (criteria and taxonomy items). While this isn't optimized for maintaining a software encyclopedia as a repository (since we have an rse.db) I can imagine some folks might want to use a relational database. This PR will also give the user the option to skip annotation of an item.

Signed-off-by: vsoch <vsochat@stanford.edu>