### PR TITLE
adding the joss scraper!

### DIFF
--- a/docs/_docs/getting-started/api.md
+++ b/docs/_docs/getting-started/api.md
@@ -23,6 +23,7 @@ If you look at the bottom of the table, there is a small link to view the tasks 
 
 ![../img/api/dashboard.png](../img/api/dashboard.png)
 
+
 ## API Views
 
  - [Api Index (root)](#index)
@@ -46,6 +47,7 @@ The first page you go to is the index, which shows the pattern for endpoints tha
 <a id="list-repos">
 ###  List Repositories
 
+
 **/api/repos**
 
 You can quickly see a listing of all repositories in the encyclopedia:
@@ -56,7 +58,8 @@ You can quickly see a listing of all repositories in the encyclopedia:
 <a id="list-parser">
 ###  List Repositories by Parser
 
-**/api/repos/parser/<name>**
+
+**/api/repos/parser/[name]**
 
 Or a listing based on the parser (e.g., GitHub)
 
@@ -66,7 +69,7 @@ Or a listing based on the parser (e.g., GitHub)
 <a id="list-repo">
 ### List Single Repository
 
-**/api/repos/<uid>**
+**/api/repos/[uid]**
 
 If you adjust the url (`/api/repos/<uid>`) to specify a particular repository, you'll see it's exported metadata:
 

--- a/docs/_docs/getting-started/commands.md
+++ b/docs/_docs/getting-started/commands.md
@@ -12,11 +12,11 @@ your software database.
  - [Exists](#exists): determine if a particular repository exists in your local repository
  - [Add](#add): add a new software repository to your database
  - [Get](#get): retrieve current metadata for a piece of software, or all software
+ - [Scrape](#scrape): automated update of new software repositories from a remote resource
  - [Update](#update): update metadata for a single repository or all repositories
  - [Label](#label) a software repository with custom metadata
  - [List](#list) all software or software specific to a parser
 
- - [Remote](#remote): query the rseng/software remote database
  - [Clear](#clear) a software repository, all under a parser, or the entire database.
  - [Search](#search) across your software to find a particular one.
  - [Shell](#shell) into a Python shell to interact with an encyclopedia client.
@@ -126,6 +126,37 @@ for you:
 ```bash
 rse get
 ```
+
+<a id="scrape">
+## Scrape
+
+Adding a repository here and there is logical, but it would be very arduous
+to need to consistently look for and add new software repositories. Toward
+this goal, the research software encyclopedia has a `scrape` command
+that will allow you to programaticaly discover new repos from some
+external resource. For example, if we wanted to query the [Journal of Open Source Software](https://joss.theoj.org/)
+
+```bash
+$ rse scrape joss
+```
+
+If you don't provide a query term, the latest set will be returned. If you do
+provide a term,
+
+```bash
+$ rse scrape joss docker
+```
+
+The term will be searched for instead. You can also do a dry run to see the 
+repos found, but not add them to the software repository:
+
+```bash
+$ rse scrape --dry-run joss
+```
+
+For more detailed scraping, it's recommended
+to interact with a scraper from within Python. See the [scrapers](../scrapers) getting
+started pages to do this.
 
 <a id="update">
 ## Update

--- a/docs/_docs/getting-started/scrapers.md
+++ b/docs/_docs/getting-started/scrapers.md
@@ -6,7 +6,9 @@ order: 5
 ---
 
 Scrapers support discovering software repositories from different resources
-that might then be added via a core [parser](../parsers).
+that might then be added via a core [parser](../parsers). By default, a scraper
+will query for some number of latest updated entries. If you provide a query
+string, it will be searched for that instead.
 
 ## How does it work?
 
@@ -27,11 +29,72 @@ but still capture metadata that we need.
 The following scrapers are planned for development, depending on if an API is available,
 and it includes links to repositories:
 
- - The Journal of Open Source Software (JoSS)
+ - [The Journal of Open Source Software (JoSS)](#joss)
  - bio.tools
  - Hal Research Software Database
  - Software Dictionary: https://research-software.nl/
 
-**under development**
 
-You might next want to learn about the interactive [dashboard]({{ site.baseurl }}/getting-started/dashboard/).
+<a id="joss">
+### Journal of Open Source Software
+
+The Journal of Open Source Software is one of my favorite resources for new
+software. Although the site has an RSS (atom) feed, you can't easily retrieve GitHub urls
+from it, so instead we parse the main site, either for latest, or based on a search
+query:
+
+```bash
+$ rse scrape joss
+INFO:rse.main.scrapers.joss:Found repository: https://github.com/LiberTEM/LiberTEM
+INFO:rse.main.scrapers.joss:Found repository: https://github.com/samhforbes/PupillometryR
+INFO:rse.main.scrapers.joss:Found repository: https://github.com/Alcampopiano/hypothesize
+INFO:rse.main.scrapers.joss:Found repository: https://github.com/BartoszBartmanski/StoSpa2
+INFO:rse.main.scrapers.joss:Found repository: https://github.com/rgmyr/corebreakout
+INFO:rse.main.scrapers.joss:Found repository: https://github.com/coljac/sensie
+INFO:rse.main.scrapers.joss:Found repository: https://github.com/HajkD/LTRpred
+INFO:rse.main.scrapers.joss:Found repository: https://github.com/mzy2240/ESA
+INFO:rse.main.scrapers.joss:Found repository: https://github.com/KVSlab/turtleFSI.git
+INFO:rse.main.scrapers.joss:Found repository: https://github.com/anmolter/XLUR
+```
+
+If you don't want to add repositories to the database (but just do a test run) add `--dry-run`
+
+```bash
+$ rse scrape --dryrun joss
+```
+
+You can also scrape based on a term of interest:
+
+```bash
+$ rse scrape --dryrun joss docker
+```
+
+And of course you can interact with a scraper from within Python! Either
+of the following will work to get the joss scraper:
+
+```python
+from rse.main.scrapers import get_named_scraper
+scraper = get_named_scraper('joss')
+```
+
+```python
+from rse.main.scrapers import JossScraper
+scraper = JossScraper('joss')
+```
+
+And then you can either search for a term, or get the latest (on the front page)
+
+```python
+results = scraper.latest()
+results = scraper.search("docker")
+```
+
+And finally, if you want to create the repos that you have (the ones that 
+don't exist in the research software encyclopedia yet) just run create.
+The results are returned above, but they are also saved to the client.
+
+```python
+scraper.create()
+```
+
+**under development**

--- a/docs/_docs/install/index.md
+++ b/docs/_docs/install/index.md
@@ -60,6 +60,13 @@ pip install rse[app]
 pip install -e .[app]
 ```
 
+if you want to use the scrapers, you need to install beautiful soup:
+
+```bash
+pip install rse[scraper]
+pip install -e .[scraper]
+```
+
 or just install all dependencies:
 
 ```bash

--- a/rse/client/__init__.py
+++ b/rse/client/__init__.py
@@ -172,6 +172,20 @@ def get_parser():
     )
     search.add_argument("query", nargs="*")
 
+    # Scrape for new repos
+    scrape = subparsers.add_parser(
+        "scrape", help="Add new software repositories from a resource.",
+    )
+    scrape.add_argument("scraper_name", nargs=1)
+    scrape.add_argument("query", nargs="?")
+    scrape.add_argument(
+        "--dry-run",
+        dest="dry_run",
+        help="Dump scrape output to the terminal, but don't create new repos.",
+        default=False,
+        action="store_true",
+    )
+
     # Shell
     subparsers.add_parser(
         "shell", help="start an interactive shell for an encyclopedia"
@@ -234,6 +248,7 @@ def get_parser():
         label,
         ls,
         search,
+        scrape,
         start,
         update,
     ]:
@@ -320,6 +335,8 @@ def main():
         from .listing import main
     if args.command == "search":
         from .search import main
+    if args.command == "scrape":
+        from .scrape import main
     if args.command == "shell":
         from .shell import main
     if args.command == "start":

--- a/rse/client/scrape.py
+++ b/rse/client/scrape.py
@@ -1,0 +1,33 @@
+"""
+
+Copyright (C) 2020 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+
+from rse.main.scrapers import get_named_scraper
+import sys
+
+
+def main(args, extra):
+
+    try:
+        scraper = get_named_scraper(args.scraper_name[0])
+    except:
+        sys.exit(f"{args.scraper_name[0]} is not a known scraper.")
+
+    # Either get latest entries, or based on search
+    if args.query is not None:
+        results = scraper.search(args.query)
+    else:
+        results = scraper.latest()
+    print("Found %s results" % len(results))
+
+    # If we have results and it's not a dry run, create the repos
+    if results and not args.dry_run:
+        scraper.create(database=args.database, config_file=args.config_file)
+    elif results and args.dry_run:
+        print(results)

--- a/rse/main/parsers/github.py
+++ b/rse/main/parsers/github.py
@@ -35,8 +35,6 @@ class GitHubParser(ParserBase):
         """load secrets, namely the GitHub token
         """
         self.token = self.get_setting("TOKEN")
-        if not self.token:
-            bot.warning("export RSE_GITHUB_TOKEN to increase API limits")
 
     def get_url(self, data=None):
         """a common function for a parser to return the html url for the

--- a/rse/main/parsers/gitlab.py
+++ b/rse/main/parsers/gitlab.py
@@ -36,8 +36,6 @@ class GitLabParser(ParserBase):
         """load secrets, namely the GitLab token
         """
         self.token = self.get_setting("TOKEN")
-        if not self.token:
-            bot.warning("Export RSE_GITLAB_TOKEN to increase API limits.")
 
     def get_url(self, data=None):
         """a common function for a parser to return the html url for the

--- a/rse/main/scrapers/__init__.py
+++ b/rse/main/scrapers/__init__.py
@@ -1,0 +1,26 @@
+"""
+
+Copyright (C) 2020 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+
+from .joss import JossScraper
+import re
+
+
+def get_named_scraper(name, config=None):
+    """get a named scraper, meaning determining based on name
+    """
+    scraper = None
+    if re.search("(joss|journal of open source software)", name, re.IGNORECASE):
+        scraper = JossScraper()
+
+    if not scraper:
+        raise NotImplementedError(f"There is no matching scraper for {name}")
+
+    scraper.config = config
+    return scraper

--- a/rse/main/scrapers/base.py
+++ b/rse/main/scrapers/base.py
@@ -1,0 +1,68 @@
+"""
+
+Copyright (C) 2020 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+
+import os
+
+
+class ScraperBase:
+    """A scraper base exists get new records from a resource.
+    """
+
+    name = "base"
+
+    def __init__(self, query=None):
+        """create a scraper. if a query term is provided, do search. Otherwise
+           do a query for latest.
+        """
+        self.query = query
+        self.results = []
+
+    def latest(self, paginate=True):
+        """The scraper should expose a function to populate self.results with
+           some number of latest entries.
+        """
+        raise NotImplementedError
+
+    def search(self, paginate=True):
+        """The scraper should expose a function to populate self.results with
+           a listing based on matching a search criteria.
+        """
+        raise NotImplementedError
+
+    def create(self, uri, **kwargs):
+        """After a scrape (whether we obtain latest or a search query) we
+           run create to create software repositories based on results.
+        """
+        raise NotImplementedError
+
+    def get_setting(self, key, default=None):
+        """Get a setting, meaning that we first check the environment, then
+           the config file, and then (if provided) a default.
+        """
+        # First preference to environment
+        envar = ("RSE_%s_%s" % (self.name, key)).upper()
+        envar = os.environ.get(envar)
+        if envar is not None:
+            return envar
+
+        # Next preference to config setting
+        parser = "scraper.%s" % self.name
+
+        # Parsers instantiated separate from database won't have config
+        if not hasattr(self, "config"):
+            return default
+        if parser not in self.config.config:
+            return default
+        if key in self.config.config[parser]:
+            return self.config.get(parser, key)
+        return default
+
+    def summary(self):
+        return "[scraper][%s][%s]" % (self.name, len(self.results))

--- a/rse/main/scrapers/joss.py
+++ b/rse/main/scrapers/joss.py
@@ -1,0 +1,99 @@
+"""
+
+Copyright (C) 2020 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+
+from rse.utils.urls import get_user_agent
+import logging
+import requests
+import random
+import sys
+import re
+from time import sleep
+
+from .base import ScraperBase
+
+bot = logging.getLogger("rse.main.scrapers.joss")
+
+
+class JossScraper(ScraperBase):
+
+    name = "joss"
+
+    def __init__(self, query=None, **kwargs):
+        super().__init__(query)
+
+    def latest(self, paginate=True):
+        """The scraper should expose a function to populate self.results with
+           some number of latest entries.
+        """
+        url = "https://joss.theoj.org/papers/published.atom"
+        return self.scrape(url)
+
+    def search(self, query, paginate=True):
+        """The scraper should expose a function to populate self.results with
+           a listing based on matching a search criteria.
+        """
+        url = "https://joss.theoj.org/papers/search?q=%s" % query
+        return self.scrape(url)
+
+    def scrape(self, url, paginate=True):
+        """A shared function to scrape a set of repositories. Since the JoSS
+           pages for a search and the base are the same, we can use a shared
+           function.
+        """
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError:
+            sys.exit("BeautifulSoup is required. pip install rse[scraper].")
+
+        response = requests.get(url, headers={"User-Agent": get_user_agent()})
+        soup = BeautifulSoup(response.text, "html5lib")
+        for link in soup.find_all("link", href=True):
+
+            # Sleep for a random amount of time to give a rest!
+            sleep(random.choice(range(1, 10)) * 0.1)
+            paper_url = link.attrs.get("href", "")
+
+            # Retrieve page with paper metadata that we need
+            if re.search(
+                "https://joss.theoj.org/papers/10.[0-9]{5}/joss.[0-9]{5}", paper_url
+            ):
+                response = requests.get(
+                    paper_url, headers={"User-Agent": get_user_agent()}
+                )
+                paper_soup = BeautifulSoup(response.text, "html5lib")
+
+                # Find links that we need
+                repo = {}
+                for link in paper_soup.find_all("a", href=True):
+                    if "Software repository" in link.text:
+                        repo["url"] = link.attrs.get("href", "")
+                    elif "Software archive" in link.text:
+                        repo["doi"] = link.attrs.get("href", "")
+
+                if repo.get("url") and repo.get("doi"):
+                    bot.info("Found repository: %s" % repo["url"])
+                    self.results.append(repo)
+
+        return self.results
+
+    def create(self, database=None, config_file=None):
+        """After a scrape (whether we obtain latest or a search query) we
+           run create to create software repositories based on results.
+        """
+        from rse.main import Encyclopedia
+
+        client = Encyclopedia(config_file=config_file, database=database)
+        for result in self.results:
+            uid = result["url"].split("//")[-1]
+
+            # Add results that don't exist
+            if not client.exists(uid):
+                client.add(uid)
+                client.label(uid, key="doi", value=result.get("doi"))

--- a/rse/utils/urls.py
+++ b/rse/utils/urls.py
@@ -1,0 +1,58 @@
+"""
+
+Copyright (C) 2020 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+
+import random
+
+
+def get_user_agent():
+    """
+    Return a randomly chosen user agent for requests
+
+    Returns:
+        user agent string to include with User-Agent.
+    """
+    agents = [
+        (
+            "Mozilla/5.0 (X11; Linux x86_64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/57.0.2987.110 "
+            "Safari/537.36"
+        ),  # chrome
+        (
+            "Mozilla/5.0 (X11; Linux x86_64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/61.0.3163.79 "
+            "Safari/537.36"
+        ),  # chrome
+        (
+            "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:55.0) "
+            "Gecko/20100101 "
+            "Firefox/55.0"
+        ),  # firefox
+        (
+            "Mozilla/5.0 (X11; Linux x86_64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/61.0.3163.91 "
+            "Safari/537.36"
+        ),  # chrome
+        (
+            "Mozilla/5.0 (X11; Linux x86_64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/62.0.3202.89 "
+            "Safari/537.36"
+        ),  # chrome
+        (
+            "Mozilla/5.0 (X11; Linux x86_64) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/63.0.3239.108 "
+            "Safari/537.36"
+        ),  # chrome
+    ]
+    return random.choice(agents)

--- a/rse/version.py
+++ b/rse/version.py
@@ -30,8 +30,9 @@ APP_REQUIRES = (
     ("gevent-websocket", {"min_version": "0.10.1"}),
 )
 
+SCRAPER_REQUIRES = (("beautifulsoup4", {"min_version": "4.9.0"}),)
 DATABASE_REQUIRES = (("sqlalchemy", {"min_version": None}),)
 TESTS_REQUIRES = (("pytest", {"min_version": "4.6.2"}),)
 
 
-ALL_REQUIRES = INSTALL_REQUIRES + DATABASE_REQUIRES + APP_REQUIRES
+ALL_REQUIRES = INSTALL_REQUIRES + DATABASE_REQUIRES + APP_REQUIRES + SCRAPER_REQUIRES

--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ if __name__ == "__main__":
     ALL_REQUIRES = get_reqs(lookup, "ALL_REQUIRES")
     APP_REQUIRES = get_reqs(lookup, "APP_REQUIRES")
     DATABASE_REQUIRES = get_reqs(lookup, "DATABASE_REQUIRES")
+    SCRAPER_REQUIRES = get_reqs(lookup, "SCRAPER_REQUIRES")
 
     setup(
         name=NAME,
@@ -98,6 +99,7 @@ if __name__ == "__main__":
         tests_require=TESTS_REQUIRES,
         extras_require={
             "database": DATABASE_REQUIRES,
+            "scraper": SCRAPER_REQUIRES,
             "app": APP_REQUIRES,
             "all": ALL_REQUIRES,
         },


### PR DESCRIPTION
Adding JoSS scraper, to address one of the points in #19. The idea of a scraper is that it can retrieve either latest or based on a query term, and given that JoSS has a DOI, we add that as metadata too. This is pretty neat because once we have a set of scrapers, we can easily run an automated nightly job to update the rseng/software database with new entries.

Signed-off-by: vsoch <vsochat@stanford.edu>