### PR TITLE
Update/zenodo identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.2.x](https://github.com/rse/rse/tree/master) (0.0.x)
+ - allowing Zenodo parser to hand off to GitLab or GitHub (0.0.16)
  - adding import of static issue (markdown) files for annotation (0.0.15)
  - adding generation of data.json to static site export (0.0.14)
  - web interface needs software (or other custom) prefix for export (0.0.13) 

--- a/rse/client/__init__.py
+++ b/rse/client/__init__.py
@@ -364,7 +364,6 @@ def main():
         from .start import main
 
     # Pass on to the correct parser
-    return_code = 0
     main(args=args, extra=extra)
 
 

--- a/rse/main/database/filesystem.py
+++ b/rse/main/database/filesystem.py
@@ -25,6 +25,7 @@ from rse.utils.file import (
 )
 from rse.main.database.base import Database
 from rse.main.parsers import get_parser
+from rse.main.parsers.base import ParserBase
 from glob import glob
 import logging
 import shutil
@@ -86,8 +87,14 @@ class FileSystemDatabase(Database):
         if uid:
             parser = get_parser(uid, config=self.config)
             data = parser.get_metadata()
+
+            # If it's a parser handoff
+            if isinstance(data, ParserBase):
+                parser = data
+                data = parser.data
+
             if data:
-                bot.info(f"{uid} was added to the the database.")
+                bot.info(f"{parser.uid} was added to the the database.")
                 return SoftwareRepository(parser, data_base=self.data_base)
         else:
             bot.error("Please define a unique identifier to add.")

--- a/rse/main/database/relational.py
+++ b/rse/main/database/relational.py
@@ -16,6 +16,7 @@ from rse.exceptions import (
 )
 from rse.main.database.base import Database
 from rse.main.parsers import get_parser
+from rse.main.parsers.base import ParserBase
 
 from sqlalchemy import create_engine, desc
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -107,6 +108,12 @@ class RelationalDatabase(Database):
         parser = get_parser(uid, config=self.config)
         if not self.exists(parser.uid):
             data = parser.get_metadata()
+
+            # If it's a parser handoff
+            if isinstance(data, ParserBase):
+                parser = data
+                data = parser.data
+
             if data:
                 repo = SoftwareRepository(
                     uid=parser.uid, parser=parser.name, data=json.dumps(parser.export())

--- a/rse/main/parsers/__init__.py
+++ b/rse/main/parsers/__init__.py
@@ -32,6 +32,8 @@ def get_parser(uri, config=None):
         parser = GitHubParser(uri)
     if matches(GitLabParser, uri):
         parser = GitLabParser(uri)
+    if matches(ZenodoParser, uri):
+        parser = ZenodoParser(uri)
 
     if not parser:
         raise NotImplementedError(f"There is no matching parser for {uri}")

--- a/rse/version.py
+++ b/rse/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.15"
+__version__ = "0.0.16"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "rse"

--- a/tests/test_parser_zenodo.py
+++ b/tests/test_parser_zenodo.py
@@ -27,7 +27,8 @@ def test_parser_zenodo(tmp_path):
         assert parser.summary()
 
     # Only test one get of data
-    assert parser.get_metadata()
+    assert not parser.get_metadata()
+    assert parser.get_metadata(require_repo=False)
     data = parser.export()
     for key in ["timestamp", "doi", "links", "metadata"]:
         assert key in data


### PR DESCRIPTION
This will allow a Zenodo parser to handoff to a core GitHub or GitLab parser to close #30. 