### PR TITLE
Adding static search to site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.0.x](https://github.com/rseng/rse/tree/master) (0.0.x)
+ - static search interface and delay parameter for scrape (0.0.22)
  - ensuring that interface generation uses constent colors (0.0.21)
  - bug that taxonomy needs newline for export (0.0.2)
  - adding analysis metrics (0.0.19)

--- a/docs/_docs/getting-started/environment.md
+++ b/docs/_docs/getting-started/environment.md
@@ -115,6 +115,15 @@ This is especially important if you are running `rse export` for GitHub
 pages, as you'll need the url prefix to coincide with the GitHub pages repository
 name.
 
+### RSE_HOST
+
+In the case that you are exporting content for GitHub pages, you'll want to export
+`RSE_HOST` to be the hostname and port that you need. For example:
+
+```bash
+export RSE_HOST=https://rseng.github.io
+```
+
 ## RSE Parsers
 
 Each parser can maintain it's own namespace of environment variables. These

--- a/rse/app/api.py
+++ b/rse/app/api.py
@@ -19,7 +19,7 @@ def list_repos(parser=None):
        and return a json list to serialize to the api view
     """
     repos = []
-    url = RSE_HOST or flask.request.host_url
+    url = (RSE_HOST or flask.request.host_url) + RSE_URL_PREFIX
     for i, repo in enumerate(app.client.list(parser)):
         repos.append(
             {
@@ -54,7 +54,7 @@ class apiGet(Resource):
 
     def get(self, uid):
         repo = app.client.get(uid)
-        return repo.export()
+        return repo.load()
 
 
 class apiEndpoints(Resource):

--- a/rse/app/api.py
+++ b/rse/app/api.py
@@ -11,7 +11,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 import flask
 from flask_restful import Resource, Api
 from rse.app.server import app
-from rse.defaults import RSE_URL_PREFIX
+from rse.defaults import RSE_URL_PREFIX, RSE_HOST
 
 
 def list_repos(parser=None):
@@ -19,12 +19,12 @@ def list_repos(parser=None):
        and return a json list to serialize to the api view
     """
     repos = []
-    url = flask.request.host_url
+    url = RSE_HOST or flask.request.host_url
     for i, repo in enumerate(app.client.list(parser)):
         repos.append(
             {
                 "uid": repo[0],
-                "html_url": "%sparser/%s" % (url, repo[0]),
+                "html_url": "%srepository/%s" % (url, repo[0]),
                 "api_url": "%sapi/repos/%s" % (url, repo[0]),
             }
         )
@@ -62,7 +62,7 @@ class apiEndpoints(Resource):
     """
 
     def get(self):
-        url = flask.request.host_url
+        url = RSE_HOST or flask.request.host_url
         return {
             "%sapi" % RSE_URL_PREFIX: "%sapi" % url,
             "%sapi/repos" % RSE_URL_PREFIX: "%sapi/repos" % url,

--- a/rse/app/api.py
+++ b/rse/app/api.py
@@ -62,7 +62,7 @@ class apiEndpoints(Resource):
     """
 
     def get(self):
-        url = RSE_HOST or flask.request.host_url
+        url = (RSE_HOST or flask.request.host_url) + RSE_URL_PREFIX
         return {
             "%sapi" % RSE_URL_PREFIX: "%sapi" % url,
             "%sapi/repos" % RSE_URL_PREFIX: "%sapi/repos" % url,

--- a/rse/app/export.py
+++ b/rse/app/export.py
@@ -94,7 +94,13 @@ def export_web_static(export_dir, base_url, client, force=False):
                 % (base_url, RSE_URL_PREFIX, repo_path, annotation_type)
             ] = os.path.join(repo_path, "annotate-%s" % annotation_type, "index.html")
 
+        # Repository API endpoints
+        urls["%s%sapi/repos/%s" % (base_url, RSE_URL_PREFIX, repo.uid)] = os.path.join(
+            "api", "repos", repo.uid, "index.json"
+        )
+
     # Add API endpoints
+    urls["%s%sapi" % (base_url, RSE_URL_PREFIX)] = os.path.join("api", "index.json")
     urls["%s%sapi/repos" % (base_url, RSE_URL_PREFIX)] = os.path.join(
         "api", "repos", "index.json"
     )

--- a/rse/app/export.py
+++ b/rse/app/export.py
@@ -104,6 +104,12 @@ def export_web_static(export_dir, base_url, client, force=False):
     urls["%s%sapi/repos" % (base_url, RSE_URL_PREFIX)] = os.path.join(
         "api", "repos", "index.json"
     )
+
+    for parser in ["github", "gitlab"]:
+        urls[
+            "%s%sapi/repos/parser/%s" % (base_url, RSE_URL_PREFIX, parser)
+        ] = os.path.join("api", "repos", "parser", parser, "index.json")
+
     urls["%s%sapi/taxonomy" % (base_url, RSE_URL_PREFIX)] = os.path.join(
         "api", "taxonomy", "index.json"
     )

--- a/rse/app/export.py
+++ b/rse/app/export.py
@@ -105,6 +105,11 @@ def export_web_static(export_dir, base_url, client, force=False):
         "api", "criteria", "index.json"
     )
 
+    # Add search
+    urls["%s%ssearch" % (base_url, RSE_URL_PREFIX)] = os.path.join(
+        "search", "index.html"
+    )
+
     for url, outfile in urls.items():
 
         # Skip if we've already created it

--- a/rse/app/templates/home/index.html
+++ b/rse/app/templates/home/index.html
@@ -56,7 +56,20 @@
     <hr>
   </div>
   <div class='col-sm-4'>
-    <h1 style="margin-left:5px; padding-top:90px"><b>Categories</b> 🦉️</h1>
+    <br>
+    <div class="form-horizontal">
+        <div class='form-group has-feedback'>
+          <div class='col-sm-12'>
+              <form action="{{ url_prefix }}search" method="get">
+                 <input class="form-control" placeholder="Search site..." name="q" type='search'>
+                 <span class='glyphicon glyphicon-remove form-control-feedback search-cancel-button'></span>
+                 <input type="submit" value="Search" style="display: none;">
+              </form>
+          </div>
+        </div>
+      <br>
+    </div>
+    <h1 style="margin-left:5px;"><b>Categories</b> 🦉️</h1>
          <hr>
         {% include "tables/taxonomy-table.html" %}
     <hr>

--- a/rse/app/templates/search.html
+++ b/rse/app/templates/search.html
@@ -1,0 +1,160 @@
+{% extends "base.html" %}
+{% block title %}The Research Software Encyclopedia Search{% endblock %}
+{% block content %}
+
+
+<div class='container-fluid'>
+  <div class='row'>
+    <div class='col-sm-8'>
+      <br>
+      <div class='form-horizontal'>
+        <div class='form-group has-feedback'>
+          <div class='col-sm-12'>
+
+<form action="{{ url_prefix }}search" method="get">
+	<input class="form-control" type="search" name="q" id="search-input" placeholder="Search..." style="margin-top:5px" autofocus>
+        <span class='glyphicon glyphicon-remove form-control-feedback search-cancel-button'></span>
+	<i style="color:white; margin-right:8px; margin-left:5px" class="fa fa-search"></i>
+	<input type="submit" value="Search" style="display: none;">
+</form>
+
+          </div>
+        </div>
+      </div>
+      <br>
+      <div class='panel panel-default'>
+
+<p><span id="search-process">Loading</span> results <span id="search-query-container" style="display: none;">for "<strong id="search-query"></strong>"</span></p>
+
+<ul id="search-results"></ul>
+
+
+       <div class="controls">
+         <span style="float:right; margin-right:30px; margin-top:20px" class="badge badge-primary">database: {{ database }}</span><a href="{{ url_prefix }}/api/repos"><span style="float:right; margin-right:30px; margin-top:20px" class="badge badge-primary">api</span></a>
+         <hr>
+         </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block footer %}
+{{ super() }}
+
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/lunr.js/2.3.8/lunr.min.js"></script>
+<script>
+window.data = {
+	{% for repo in repos %}
+	"{{ repo.uid }}": {
+	"id": "{{ repo.uid }}",
+	"title": "{{ repo.uid }}",
+	"url": " {{ repo.html_url }}",
+	"content": "{{ repo.description }}"
+	}{% if loop.last %}{% else %},{% endif %}{% endfor %}
+};
+
+
+(function () {
+	function getQueryVariable(variable) {
+		var query = window.location.search.substring(1),
+			vars = query.split("&");
+
+		for (var i = 0; i < vars.length; i++) {
+			var pair = vars[i].split("=");
+
+			if (pair[0] === variable) {
+				return decodeURIComponent(pair[1].replace(/\+/g, '%20')).trim();
+			}
+		}
+	}
+
+	function getPreview(query, content, previewLength) {
+		previewLength = previewLength || (content.length * 2);
+
+		var parts = query.split(" "),
+			match = content.toLowerCase().indexOf(query.toLowerCase()),
+			matchLength = query.length,
+			preview;
+
+		// Find a relevant location in content
+		for (var i = 0; i < parts.length; i++) {
+			if (match >= 0) {
+				break;
+			}
+
+			match = content.toLowerCase().indexOf(parts[i].toLowerCase());
+			matchLength = parts[i].length;
+		}
+
+		// Create preview
+		if (match >= 0) {
+			var start = match - (previewLength / 2),
+				end = start > 0 ? match + matchLength + (previewLength / 2) : previewLength;
+
+			preview = content.substring(start, end).trim();
+
+			if (start > 0) {
+				preview = "..." + preview;
+			}
+
+			if (end < content.length) {
+				preview = preview + "...";
+			}
+
+			// Highlight query parts
+			preview = preview.replace(new RegExp("(" + parts.join("|") + ")", "gi"), "<strong>$1</strong>");
+		} else {
+			// Use start of content if no match found
+			preview = content.substring(0, previewLength).trim() + (content.length > previewLength ? "..." : "");
+		}
+
+		return preview;
+	}
+
+	function displaySearchResults(results, query) {
+		var searchResultsEl = document.getElementById("search-results"),
+			searchProcessEl = document.getElementById("search-process");
+
+		if (results.length) {
+			var resultsHTML = "";
+			results.forEach(function (result) {
+				var item = window.data[result.ref],
+					contentPreview = getPreview(query, item.content, 170),
+					titlePreview = getPreview(query, item.title);
+
+				resultsHTML += "<li><h4><a href='" + item.url.trim() + "'>" + titlePreview + "</a></h4><p><small>" + contentPreview + "</small></p></li>";
+			});
+
+			searchResultsEl.innerHTML = resultsHTML;
+			searchProcessEl.innerText = "Showing";
+		} else {
+			searchResultsEl.style.display = "none";
+			searchProcessEl.innerText = "No";
+		}
+	}
+
+	window.index = lunr(function () {
+		this.field("id");
+		this.field("title", {boost: 10});
+		this.field("url");
+		this.field("content");
+		for (var key in window.data) {
+			this.add(window.data[key]);
+		}
+
+	});
+
+	var query = decodeURIComponent((getQueryVariable("q") || "").replace(/\+/g, "%20")),
+		searchQueryContainerEl = document.getElementById("search-query-container"),
+		searchQueryEl = document.getElementById("search-query");
+
+	searchQueryEl.innerText = query;
+        if (query != ""){
+   		searchQueryContainerEl.style.display = "inline";
+        }
+
+	displaySearchResults(window.index.search(query), query); // Hand the results off to be displayed
+})();
+</script>
+{% endblock %}

--- a/rse/app/views/main.py
+++ b/rse/app/views/main.py
@@ -10,7 +10,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from flask import render_template
 from rse.app.server import app
-from rse.defaults import RSE_URL_PREFIX
+from rse.defaults import RSE_URL_PREFIX, RSE_HOST
 
 import flask
 
@@ -34,7 +34,7 @@ def index():
 @app.route("%ssearch" % RSE_URL_PREFIX)
 def search():
     repos = []
-    url = flask.request.host_url + RSE_URL_PREFIX
+    url = RSE_HOST + RSE_URL_PREFIX or flask.request.host_url + RSE_URL_PREFIX
     for i, name in enumerate(app.client.list()):
         repo = app.client.get(name[0])
         repos.append(

--- a/rse/app/views/main.py
+++ b/rse/app/views/main.py
@@ -12,6 +12,8 @@ from flask import render_template
 from rse.app.server import app
 from rse.defaults import RSE_URL_PREFIX
 
+import flask
+
 ## Main Index View
 
 
@@ -26,4 +28,27 @@ def index():
         entries=app.client.list_taxonomy(),
         url_prefix=RSE_URL_PREFIX,
         enable_annotate=not app.disable_annotate,
+    )
+
+
+@app.route("%ssearch" % RSE_URL_PREFIX)
+def search():
+    repos = []
+    url = flask.request.host_url + RSE_URL_PREFIX
+    for i, name in enumerate(app.client.list()):
+        repo = app.client.get(name[0])
+        repos.append(
+            {
+                "uid": repo.uid,
+                "description": repo.description,
+                "url": repo.url,
+                "html_url": "%srepository/%s" % (url, repo.uid),
+                "api_url": "%sapi/repos/%s" % (url, repo.uid),
+            }
+        )
+    return render_template(
+        "search.html",
+        repos=repos,
+        database=app.client.database,
+        url_prefix=RSE_URL_PREFIX,
     )

--- a/rse/client/__init__.py
+++ b/rse/client/__init__.py
@@ -237,6 +237,13 @@ def get_parser():
         default=False,
         action="store_true",
     )
+    scrape.add_argument(
+        "--delay",
+        dest="delay",
+        help="Number of seconds (float) to delay, default 0.",
+        type=float_type,
+        default=0.0,
+    )
 
     # Shell
     subparsers.add_parser(
@@ -344,6 +351,17 @@ def percentage_type_asint(arg):
         raise argparse.ArgumentTypeError("Must be a floating point number")
     if number < 0 or number > 1:
         raise argparse.ArgumentTypeError("Argument must be between 0 and 1")
+    return number
+
+
+def float_type(arg):
+    """ensure that an input is greater than 0 and a float"""
+    try:
+        number = float(arg)
+    except ValueError:
+        raise argparse.ArgumentTypeError("Must be a floating point number")
+    if number < 0:
+        raise argparse.ArgumentTypeError("Argument must be greater than 0.")
     return number
 
 

--- a/rse/client/scrape.py
+++ b/rse/client/scrape.py
@@ -21,9 +21,9 @@ def main(args, extra):
 
     # Either get latest entries, or based on search
     if args.query is not None:
-        results = scraper.search(args.query)
+        results = scraper.search(args.query, delay=args.delay)
     else:
-        results = scraper.latest()
+        results = scraper.latest(delay=args.delay)
     print("Found %s results" % len(results))
 
     # If we have results and it's not a dry run, create the repos

--- a/rse/defaults.py
+++ b/rse/defaults.py
@@ -57,6 +57,8 @@ RSE_PARSERS = ["github"]
 RSE_API_ENDPOINT = getenv("RSE_API_ENDPOINT", "https://rseng.github.io/rseng/api")
 RSE_ISSUE_ENDPOINT = getenv("RSE_ISSUE_ENDPOINT", "https://github.com/rseng/software")
 RSE_HOST = getenv("RSE_HOST")
+if RSE_HOST and not RSE_HOST.endswith("/"):
+    RSE_HOST = "%s/" % RSE_HOST
 
 # MUST start and end with slash
 RSE_URL_PREFIX = getenv("RSE_URL_PREFIX", "/")

--- a/rse/defaults.py
+++ b/rse/defaults.py
@@ -57,8 +57,8 @@ RSE_PARSERS = ["github"]
 RSE_API_ENDPOINT = getenv("RSE_API_ENDPOINT", "https://rseng.github.io/rseng/api")
 RSE_ISSUE_ENDPOINT = getenv("RSE_ISSUE_ENDPOINT", "https://github.com/rseng/software")
 RSE_HOST = getenv("RSE_HOST")
-if RSE_HOST and not RSE_HOST.endswith("/"):
-    RSE_HOST = "%s/" % RSE_HOST
+if RSE_HOST and RSE_HOST.endswith("/"):
+    RSE_HOST = RSE_HOST.rstrip("/")
 
 # MUST start and end with slash
 RSE_URL_PREFIX = getenv("RSE_URL_PREFIX", "/")

--- a/rse/defaults.py
+++ b/rse/defaults.py
@@ -56,6 +56,7 @@ RSE_PARSERS = ["github"]
 # Default taxonomy and criteria endpoints, and place to post annotation issues
 RSE_API_ENDPOINT = getenv("RSE_API_ENDPOINT", "https://rseng.github.io/rseng/api")
 RSE_ISSUE_ENDPOINT = getenv("RSE_ISSUE_ENDPOINT", "https://github.com/rseng/software")
+RSE_HOST = getenv("RSE_HOST")
 
 # MUST start and end with slash
 RSE_URL_PREFIX = getenv("RSE_URL_PREFIX", "/")

--- a/rse/main/scrapers/base.py
+++ b/rse/main/scrapers/base.py
@@ -24,13 +24,13 @@ class ScraperBase:
         self.query = query
         self.results = []
 
-    def latest(self, paginate=True):
+    def latest(self, paginate=True, delay=0.0):
         """The scraper should expose a function to populate self.results with
            some number of latest entries.
         """
         raise NotImplementedError
 
-    def search(self, paginate=True):
+    def search(self, paginate=True, delay=0.0):
         """The scraper should expose a function to populate self.results with
            a listing based on matching a search criteria.
         """

--- a/rse/main/scrapers/biotools.py
+++ b/rse/main/scrapers/biotools.py
@@ -28,22 +28,22 @@ class BioToolsScraper(ScraperBase):
     def __init__(self, query=None, **kwargs):
         super().__init__(query)
 
-    def latest(self, paginate=False):
+    def latest(self, paginate=False, delay=0.0):
         """populate self.results with some number of latest entries. Unlike 
            a search, a latest scraper does not by default paginate. The user 
            needs to interact directly with the Python client to scrape all.
         """
         url = "https://bio.tools/api/tool/?format=json"
-        return self.scrape(url, paginate=paginate)
+        return self.scrape(url, paginate=paginate, delay=delay)
 
-    def search(self, query, paginate=True):
+    def search(self, query, paginate=True, delay=0.0):
         """populate self.results with a listing based on matching a search criteria.
            we search the description.
         """
         url = 'https://bio.tools/api/t/?description="%s"&format=json' % query
-        return self.scrape(url, paginate=paginate)
+        return self.scrape(url, paginate=paginate, delay=delay)
 
-    def scrape(self, url, paginate=False):
+    def scrape(self, url, paginate=False, delay=None):
         """A shared function to scrape a set of repositories. Since the JoSS
            pages for a search and the base are the same, we can use a shared
            function.
@@ -91,7 +91,7 @@ class BioToolsScraper(ScraperBase):
                 self.results.append(repo)
 
                 # Sleep for a random amount of time to give a rest!
-                sleep(random.choice(range(1, 10)) * 0.1)
+                sleep(delay or random.choice(range(1, 10)) * 0.1)
 
         return self.results
 

--- a/rse/main/scrapers/hal.py
+++ b/rse/main/scrapers/hal.py
@@ -13,6 +13,7 @@ from rse.main.parsers import get_parser
 import logging
 import requests
 import re
+import time
 
 from .base import ScraperBase
 
@@ -29,16 +30,16 @@ class HalScraper(ScraperBase):
     def __init__(self, query=None, **kwargs):
         super().__init__(query)
 
-    def latest(self, paginate=False):
+    def latest(self, paginate=False, delay=0.0):
         """populate self.results with some number of latest entries. Unlike 
            a search, a latest scraper does not by default paginate. Hal will by
            default return all entries, so the user is required to define a number
            for latest.
         """
         url = "https://api.archives-ouvertes.fr/search/?q=github&fq=docType_s:(SOFTWARE)&wt=json"
-        return self.scrape(url)
+        return self.scrape(url, delay=delay)
 
-    def search(self, query, paginate=True):
+    def search(self, query, paginate=True, delay=0.0):
         """populate self.results with a listing based on matching a search criteria.
            we search the description.
         """
@@ -46,9 +47,9 @@ class HalScraper(ScraperBase):
             "http://api.archives-ouvertes.fr/search/?q=%s&fq=docType_s:(SOFTWARE)&wt=json"
             % query
         )
-        return self.scrape(url)
+        return self.scrape(url, delay=delay)
 
-    def scrape(self, url, paginate=False):
+    def scrape(self, url, paginate=False, delay=0.0):
         """A shared function to scrape a set of repositories. Since the JoSS
            pages for a search and the base are the same, we can use a shared
            function.
@@ -69,6 +70,7 @@ class HalScraper(ScraperBase):
             if repo_url:
                 bot.info("Found repository: %s" % repo_url)
                 self.results.append(repo_url)
+            time.sleep(delay)
 
         return self.results
 

--- a/rse/main/scrapers/joss.py
+++ b/rse/main/scrapers/joss.py
@@ -29,23 +29,23 @@ class JossScraper(ScraperBase):
     def __init__(self, query=None, **kwargs):
         super().__init__(query)
 
-    def latest(self, paginate=False):
+    def latest(self, paginate=False, delay=0.0):
         """The scraper should expose a function to populate self.results with
            some number of latest entries. Unlike a search, a latest scraper does
            not by default paginate. The user needs to interact directly with
            the Python client to do a scrape for all papers in JoSS.
         """
         url = "https://joss.theoj.org/papers/published.atom"
-        return self.scrape(url, paginate=paginate)
+        return self.scrape(url, paginate=paginate, delay=delay)
 
-    def search(self, query, paginate=True):
+    def search(self, query, paginate=True, delay=0.0):
         """The scraper should expose a function to populate self.results with
            a listing based on matching a search criteria.
         """
         url = "https://joss.theoj.org/papers/search?q=%s" % query
-        return self.scrape(url, paginate=paginate)
+        return self.scrape(url, paginate=paginate, delay=delay)
 
-    def scrape(self, url, paginate=False):
+    def scrape(self, url, paginate=False, delay=None):
         """A shared function to scrape a set of repositories. Since the JoSS
            pages for a search and the base are the same, we can use a shared
            function.
@@ -64,7 +64,7 @@ class JossScraper(ScraperBase):
             for link in soup.find_all("link", href=True):
 
                 # Sleep for a random amount of time to give a rest!
-                sleep(random.choice(range(1, 10)) * 0.1)
+                sleep(delay or random.choice(range(1, 10)) * 0.1)
                 paper_url = link.attrs.get("href", "")
 
                 # If we don't have the next page yet

--- a/rse/main/scrapers/rsnl.py
+++ b/rse/main/scrapers/rsnl.py
@@ -12,6 +12,7 @@ from rse.utils.urls import get_user_agent, check_response
 from rse.main.parsers import get_parser
 import logging
 import requests
+import time
 
 from .base import ScraperBase
 
@@ -25,15 +26,15 @@ class RSNLScraper(ScraperBase):
     def __init__(self, query=None, **kwargs):
         super().__init__(query)
 
-    def latest(self, paginate=False):
+    def latest(self, paginate=False, delay=0.0):
         """The scraper should expose a function to populate self.results with
            some number of latest entries. Unlike a search, a latest scraper does
            not by default paginate.
         """
         url = "https://research-software.nl/api/software"
-        return self.scrape(url)
+        return self.scrape(url, delay=delay)
 
-    def search(self, query, paginate=True):
+    def search(self, query, paginate=True, delay=0.0):
         """The scraper should expose a function to populate self.results with
            a listing based on matching a search criteria.
         """
@@ -41,9 +42,9 @@ class RSNLScraper(ScraperBase):
         bot.warning(
             "The RSNL scraper does not support search, returning latest instead."
         )
-        return self.latest(paginate)
+        return self.latest(paginate, delay=delay)
 
-    def scrape(self, url, paginate=False):
+    def scrape(self, url, paginate=False, delay=0.0):
         """A shared function to scrape a set of repositories. Since the JoSS
            pages for a search and the base are the same, we can use a shared
            function.
@@ -64,6 +65,7 @@ class RSNLScraper(ScraperBase):
             elif repo_url:
                 bot.info("Found repository: %s" % repo_url)
                 self.results.append({"url": repo_url})
+            time.sleep(delay)
 
         return self.results
 

--- a/rse/version.py
+++ b/rse/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.21"
+__version__ = "0.0.22"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "rse"


### PR DESCRIPTION
This will address the following issues:

 - #38 currently the search is just for GitHub repo names in the front table. This addition adds a static search page that searches across repo descriptions, and links to them.
 - #37 an optional delay that can be set for a scraper in case more time is needed between calls. By default some of the scrapers (e.g., JoSS) already have a random delay, so this would set that to a constant.

Signed-off-by: vsoch <vsochat@stanford.edu>