### PR TITLE
updating to allow for update --rewrite and simpler metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.0.x](https://github.com/rseng/rse/tree/master) (0.0.x)
+ - streamline data export to included minimal repo data (0.0.23)
  - static search interface and delay parameter for scrape (0.0.22)
  - ensuring that interface generation uses constent colors (0.0.21)
  - bug that taxonomy needs newline for export (0.0.2)

--- a/docs/_docs/getting-started/commands.md
+++ b/docs/_docs/getting-started/commands.md
@@ -197,7 +197,15 @@ We would update in bulk as follows:
 $ rse update --file repos.txt
 ```
 
-By default, repos that are not present will be skipped over.
+By default, repos that are not present will be skipped over. If you want
+to rewrite existing metadata (for example, if you change the structure of the data)
+you can add the `--rewrite` flag:
+
+```bash
+$ rse update --file repos.txt --rewrite
+```
+
+This works for single repository updates as well.
 
 <a id="label">
 ## Label

--- a/rse/app/views/repositories.py
+++ b/rse/app/views/repositories.py
@@ -8,10 +8,9 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-from flask import render_template, request, redirect
+from flask import render_template, request
 from rse.app.server import app
 from rse.defaults import RSE_URL_PREFIX, RSE_ISSUE_ENDPOINT
-import random
 
 ## Repository Views
 
@@ -166,7 +165,7 @@ def annotate_taxonomy():
             url_prefix=RSE_URL_PREFIX,
         )
 
-    except StopIteration as exc:
+    except StopIteration:
         return annotate_repos(
             message="You have already annotated taxonomy items for all the repos!"
         )

--- a/rse/client/__init__.py
+++ b/rse/client/__init__.py
@@ -211,6 +211,13 @@ def get_parser():
         default=False,
         action="store_true",
     )
+    update.add_argument(
+        "--rewrite",
+        dest="rewrite",
+        help="If data exists, don't update but rewrite.",
+        default=False,
+        action="store_true",
+    )
 
     # List repos and print to terminal
     ls = subparsers.add_parser("ls", help="List software")

--- a/rse/client/export.py
+++ b/rse/client/export.py
@@ -24,10 +24,11 @@ def main(args, extra):
 
     # Case 1: empty list indicates listing all
     if os.path.exists(args.path) and not args.force:
-        bot.error("{args.path} already exists, use --force to overwrite it.")
+        bot.error(f"{args.path} already exists, use --force to overwrite it.")
 
     # Export a list of repos
     if args.export_type == "repos-txt":
+
         # We just want the unique id, the first result
         repos = [x[0] for x in client.list()]
         write_file(args.path, "\n".join(repos))

--- a/rse/client/update.py
+++ b/rse/client/update.py
@@ -18,6 +18,6 @@ def main(args, extra):
 
     # If a file is provided:
     if args.file:
-        enc.bulk_update(args.file)
+        enc.bulk_update(args.file, rewrite=args.rewrite)
     else:
-        enc.update(args.uid)
+        enc.update(args.uid, rewrite=args.rewrite)

--- a/rse/main/__init__.py
+++ b/rse/main/__init__.py
@@ -117,7 +117,7 @@ class Encyclopedia:
                 repos += [self.add(uid, quiet=True)] or []
         return repos
 
-    def bulk_update(self, filename):
+    def bulk_update(self, filename, rewrite=False):
         """Given a filename with a single list of repos, add each
         """
         repos = []
@@ -125,7 +125,7 @@ class Encyclopedia:
             for name in read_file(filename):
                 uid = name.strip()
                 try:
-                    repos += [self.update(uid)]
+                    repos += [self.update(uid, rewrite=rewrite)]
                 except RepoNotFoundError:
                     pass
         return repos
@@ -176,12 +176,12 @@ class Encyclopedia:
         else:
             raise RuntimeError(f"Unrecognized {target} to clear")
 
-    def update(self, uid):
+    def update(self, uid, rewrite=False):
         """Update an existing software repository.
         """
         try:
             repo = self.get(uid)
-            self.db.update(repo)
+            self.db.update(repo, rewrite=rewrite)
             bot.info(f"{repo.uid} has been updated.")
             return repo
         except RepoNotFoundError:

--- a/rse/main/database/filesystem.py
+++ b/rse/main/database/filesystem.py
@@ -127,13 +127,16 @@ class FileSystemDatabase(Database):
         parser = get_parser(uid, config=self.config)
         return SoftwareRepository(parser, exists=True, data_base=self.data_base)
 
-    def update(self, repo):
+    def update(self, repo, rewrite=False):
         """Update a repository by retrieving metadata, and then calling update 
            on the software repository to save it.
         """
         data = repo.parser.get_metadata()
         if data:
-            repo.update()
+            if rewrite:
+                self.add(repo.uid)
+            else:
+                repo.update()
 
     def label(self, repo, key, value, force=False):
         """Update a repository with a specific key/value pair.

--- a/rse/main/database/relational.py
+++ b/rse/main/database/relational.py
@@ -124,7 +124,7 @@ class RelationalDatabase(Database):
                 repo.parser = parser
                 return repo
 
-    def update(self, repo, updates=None):
+    def update(self, repo, updates=None, rewrite=False):
         """update a repo with a json dictionary.
         """
         # Return of None indicates non-success
@@ -135,7 +135,7 @@ class RelationalDatabase(Database):
 
             # Load the previous data to update
             data = {}
-            if repo.data:
+            if repo.data and not rewrite:
                 data = json.loads(repo.data)
             data.update(updates)
             repo.data = json.dumps(data)

--- a/rse/main/parsers/github.py
+++ b/rse/main/parsers/github.py
@@ -78,5 +78,33 @@ class GitHubParser(ParserBase):
         response = requests.get(url, headers=headers)
 
         # Successful query!
-        self.data = check_response(response)
+        data = check_response(response)
+
+        # Only save minimal set
+        self.data = {}
+        for key in [
+            "name",
+            "url",
+            "full_name",
+            "html_url",
+            "private",
+            "description",
+            "created_at",
+            "updated_at",
+            "clone_url",
+            "homepage",
+            "size",
+            "stargazers_count",
+            "watchers_count",
+            "language",
+            "open_issues_count",
+            "license",
+            "subscribers_count",
+        ]:
+            if key in data:
+                self.data[key] = data[key]
+        self.data["owner"] = {}
+        for key in ["html_url", "avatar_url", "login", "type"]:
+            self.data["owner"][key] = data["owner"][key]
+
         return self.data

--- a/rse/version.py
+++ b/rse/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.22"
+__version__ = "0.0.23"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "rse"


### PR DESCRIPTION
We should be only saving the minimum amount of metadata needed to parse a basic interface and allow for annotation of a repository.

Signed-off-by: vsoch <vsochat@stanford.edu>