### PR TITLE
adding topics as client command to show and search topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.0.x](https://github.com/rseng/rse/tree/master) (0.0.x)
+ - adding topics to GitHub request (0.0.29)
  - scraper should not fail on invalid URL (0.0.28)
  - bug with reading in taxonomy lines (0.0.27)
  - bug in github parser (0.0.26)

--- a/docs/_docs/getting-started/commands.md
+++ b/docs/_docs/getting-started/commands.md
@@ -694,3 +694,19 @@ singularityhub
 web-scraping
 webscraping
 ```
+
+Finally, you can provide one or more topics, and find repositories that are labeled 
+as such:
+
+```bash
+$ rse topics --search science
+INFO:rse.main:Database: filesystem
+github/JuliaLang/julia
+github/MD-Studio/MDStudio
+github/MDAnalysis/mdanalysis
+github/SCM-NV/qmflows
+github/SCM-NV/qmflows-namd
+github/astropy/astropy
+github/hpcng/singularity
+github/recipy/recipy
+```

--- a/docs/_docs/getting-started/commands.md
+++ b/docs/_docs/getting-started/commands.md
@@ -24,7 +24,7 @@ your software database.
  - [Analyze](#analyze) a specific software repository, indicating a consensus/summary about criteria and taxonomy.
  - [Shell](#shell) into a Python shell to interact with an encyclopedia client.
  - [Start](#start) an interactive dashboard to see software and annotate crtieria and taxonomy membership.
-
+ - [Topics](#topics) list topics (tags) associated with a repository
 
 <a id="exists">
 ## Exists
@@ -612,3 +612,85 @@ $ rse start --port 8000 --host 0.0.0.0
 For each, you can specify a particular action (e.g., delete or re-run)
 or click on it for further details.  See the [dashboard]({{ site.baseurl }}/getting-started/dashboard/) 
 documentation page for more details.
+
+<a id="topics">
+
+## Topics
+
+As of version 0.0.29, the Research Software Encyclopedia has support for topics,
+primarily for the GitHub parser. If you have an older verison you can update your
+metadata with:
+
+```bash
+rse update github/<usename>/<repo>
+```
+
+or export all names to file, and bulk update
+
+```bash
+rse export repos.txt
+rse update --file repos.txt
+```
+
+Then you can ask to list topics, for example filtered by a pattern:
+
+```bash
+$ rse topics --pattern meta
+INFO:rse.main:Database: filesystem
+metadata-extraction
+metadata
+```
+
+If you want to see topics for a single repository, they are part of the standard
+metadata returned by get:
+
+```bash
+$ rse get github/<usename>/<repo>
+```
+
+If you want to list all unique topics:
+
+```bash
+$ rse topics
+INFO:rse.main:Database: filesystem
+cli
+client
+cloud-native
+container
+container-friends
+container-orchestration
+containers
+cosmology
+date
+date-parser
+datetime
+docker
+entity-extraction
+hdf5
+hpc
+html-parsing
+information-extraction
+linux
+management
+metadata
+metadata-extraction
+natural-language-processing
+nlp
+parallel
+particle
+portability
+portable
+registry
+reproducible
+reproducible-science
+rootless-containers
+science
+singularity
+singularity-compose
+singularity-container
+singularity-containers
+singularity-python
+singularityhub
+web-scraping
+webscraping
+```

--- a/rse/app/views/repositories.py
+++ b/rse/app/views/repositories.py
@@ -12,36 +12,6 @@ from flask import render_template, request
 from rse.app.server import app
 from rse.defaults import RSE_URL_PREFIX, RSE_ISSUE_ENDPOINT
 
-## Topics View
-
-
-@app.route("%stopics" % RSE_URL_PREFIX)
-def topics_view(uid):
-
-    # Obtain the repository and load the data.
-    repo = app.client.get(uid)
-    repo.parser.load(repo.data)
-
-    if repo.parser.name == "github":
-        skips = ["owner", "organization", "node_id"]
-        return render_template(
-            "parsers/github.html",
-            repo=repo.load(),
-            database=app.client.database,
-            url_prefix=RSE_URL_PREFIX,
-            skips=skips,
-        )
-    elif repo.parser.name == "gitlab":
-        avatar = repo.parser.get_avatar()
-        return render_template(
-            "parsers/gitlab.html",
-            repo=repo.load(),
-            url_prefix=RSE_URL_PREFIX,
-            database=app.client.database,
-            avatar=avatar,
-        )
-
-
 ## Repository Views
 
 

--- a/rse/app/views/repositories.py
+++ b/rse/app/views/repositories.py
@@ -12,6 +12,36 @@ from flask import render_template, request
 from rse.app.server import app
 from rse.defaults import RSE_URL_PREFIX, RSE_ISSUE_ENDPOINT
 
+## Topics View
+
+
+@app.route("%stopics" % RSE_URL_PREFIX)
+def topics_view(uid):
+
+    # Obtain the repository and load the data.
+    repo = app.client.get(uid)
+    repo.parser.load(repo.data)
+
+    if repo.parser.name == "github":
+        skips = ["owner", "organization", "node_id"]
+        return render_template(
+            "parsers/github.html",
+            repo=repo.load(),
+            database=app.client.database,
+            url_prefix=RSE_URL_PREFIX,
+            skips=skips,
+        )
+    elif repo.parser.name == "gitlab":
+        avatar = repo.parser.get_avatar()
+        return render_template(
+            "parsers/gitlab.html",
+            repo=repo.load(),
+            url_prefix=RSE_URL_PREFIX,
+            database=app.client.database,
+            avatar=avatar,
+        )
+
+
 ## Repository Views
 
 

--- a/rse/client/__init__.py
+++ b/rse/client/__init__.py
@@ -219,6 +219,23 @@ def get_parser():
         action="store_true",
     )
 
+    # List topics (global) or matching pattern
+    topics = subparsers.add_parser(
+        "topics", help="List software topics (GitHub support only)"
+    )
+    topics.add_argument(
+        "--pattern",
+        help="filter topics to a particular pattern",
+        type=str,
+        default=None,
+    )
+    topics.add_argument(
+        "--search",
+        help="find repositories based on a list of topics",
+        type=str,
+        nargs="*",
+    )
+
     # List repos and print to terminal
     ls = subparsers.add_parser("ls", help="List software")
     ls.add_argument(
@@ -325,6 +342,7 @@ def get_parser():
         scrape,
         start,
         summary,
+        topics,
         update,
     ]:
         command.add_argument(
@@ -452,6 +470,8 @@ def main():
         from .shell import main
     if args.command == "start":
         from .start import main
+    if args.command == "topics":
+        from .topics import main
 
     # Pass on to the correct parser
     main(args=args, extra=extra)

--- a/rse/client/topics.py
+++ b/rse/client/topics.py
@@ -1,0 +1,26 @@
+"""
+
+Copyright (C) 2020 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+
+from rse.main import Encyclopedia
+from rse.logger import bot
+
+
+def main(args, extra):
+
+    # Create an encyclopedia object
+    enc = Encyclopedia(config_file=args.config_file, database=args.database)
+
+    # Does the user want to search for repos with one or more topics?
+    if not args.search:
+        topics = enc.topics(pattern=args.pattern)
+        print("\n".join(topics))
+    else:
+        repos = enc.repos_by_topics(topics=args.search)
+        print("\n".join(repos))

--- a/rse/main/__init__.py
+++ b/rse/main/__init__.py
@@ -212,6 +212,34 @@ class Encyclopedia:
             return results
         bot.info(f"No results matching {query}")
 
+    # Topics
+
+    def topics(self, pattern=None):
+        """return a list of unique topics, optionally matching a pattern
+        """
+        topics = set()
+        for name in self.list():
+            repo = self.get(name[0])
+            topiclist = repo.data.get("topics", [])
+            if pattern is not None:
+                topiclist = [t for t in topiclist if re.search(pattern, t)]
+
+            # Add to topics set
+            [topics.add(t) for t in topiclist]
+        return sorted(list(topics))
+
+    def repos_by_topics(self, topics):
+        """return a list of unique topics, optionally matching a pattern
+        """
+        repos = []
+        for name in self.list():
+            repo = self.get(name[0])
+            topiclist = repo.data.get("topics", [])
+            if set(topics).intersection(set(topiclist)):
+                repos.append(repo.uid)
+
+        return sorted(repos)
+
     # Save Handlers
 
     def save_criteria(self, repo):

--- a/rse/main/__init__.py
+++ b/rse/main/__init__.py
@@ -22,6 +22,7 @@ from rse.main.criteria import get_criteria
 from rse.main.taxonomy import get_taxonomy
 from rse.logger.message import bot as message
 
+import json
 import logging
 import os
 import re
@@ -220,7 +221,14 @@ class Encyclopedia:
         topics = set()
         for name in self.list():
             repo = self.get(name[0])
-            topiclist = repo.data.get("topics", [])
+
+            # Relational needs to load from string
+            data = repo.data
+            if isinstance(data, str):
+                data = json.loads(data)
+
+            # Get the list of topics, optionally filter by a pattern
+            topiclist = data.get("topics", [])
             if pattern is not None:
                 topiclist = [t for t in topiclist if re.search(pattern, t)]
 
@@ -234,7 +242,7 @@ class Encyclopedia:
         repos = []
         for name in self.list():
             repo = self.get(name[0])
-            topiclist = repo.data.get("topics", [])
+            topiclist = repo.parser.get_metadata().get("topics", [])
             if set(topics).intersection(set(topiclist)):
                 repos.append(repo.uid)
 

--- a/rse/main/database/filesystem.py
+++ b/rse/main/database/filesystem.py
@@ -136,7 +136,7 @@ class FileSystemDatabase(Database):
             if rewrite:
                 self.add(repo.uid)
             else:
-                repo.update()
+                repo.update(updates=data)
 
     def label(self, repo, key, value, force=False):
         """Update a repository with a specific key/value pair.
@@ -163,6 +163,12 @@ class FileSystemDatabase(Database):
         if self.exists(uid):
             repo = self.get(uid)
             os.remove(repo.filename)
+
+            # Remove the directory if no other repos
+            dirname = os.path.dirname(repo.filename)
+            if not os.listdir(dirname):
+                shutil.rmtree(dirname)
+
             bot.info(f"{uid} has been removed.")
             return True
 

--- a/rse/main/parsers/github.py
+++ b/rse/main/parsers/github.py
@@ -109,4 +109,14 @@ class GitHubParser(ParserBase):
         for key in ["html_url", "avatar_url", "login", "type"]:
             self.data["owner"][key] = data["owner"][key]
 
+        # Also try to get topics
+        headers.update({"Accept": "application/vnd.github.mercy-preview+json"})
+        url = "%s/topics" % url
+        response = requests.get(url, headers=headers)
+
+        # Successful query!
+        topics = check_response(response)
+        if topics is not None:
+            self.data["topics"] = topics.get("names", [])
+
         return self.data

--- a/rse/utils/urls.py
+++ b/rse/utils/urls.py
@@ -29,7 +29,9 @@ def check_response(response):
         bot.error(f"Cannot find endpoint {response.url}.")
 
     elif response.status_code in [400, 401, 403]:
-        bot.error(f"Permission denied to query {response.url}")
+        bot.error(
+            f"Permission denied to query {response.url}: {response.status_code}, {response.reason}"
+        )
 
     else:
         bot.error(

--- a/rse/version.py
+++ b/rse/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.28"
+__version__ = "0.0.29"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "rse"

--- a/tests/test_client.sh
+++ b/tests/test_client.sh
@@ -48,6 +48,18 @@ echo "#### Testing [filesystem] rse ls"""
 runTest 0 $output rse --config_file $config/rse.ini ls
 
 echo
+echo "#### Testing [filesystem] rse topics"""
+runTest 0 $output rse --config_file $config/rse.ini topics
+
+echo
+echo "#### Testing [filesystem] rse topics with pattern"""
+runTest 0 $output rse --config_file $config/rse.ini topics --pattern singularity
+
+echo
+echo "#### Testing [filesystem] rse repos from topics"""
+runTest 0 $output rse --config_file $config/rse.ini topics --search singularity
+
+echo
 echo "#### Testing [filesystem] rse export"""
 runTest 0 $output rse --config_file $config/rse.ini export $tmpdir/filesystem-repos.txt
 runTest 0 $output ls $tmpdir/filesystem-repos.txt
@@ -91,6 +103,18 @@ runTest 0 $output rse --config_file $config/rse.ini add github.com/singularityhu
 echo
 echo "#### Testing [sqlite] rse ls"""
 runTest 0 $output rse --config_file $config/rse.ini ls
+
+echo
+echo "#### Testing [sqlite] rse topics"""
+runTest 0 $output rse --config_file $config/rse.ini topics
+
+echo
+echo "#### Testing [sqlite] rse topics with pattern"""
+runTest 0 $output rse --config_file $config/rse.ini topics --pattern singularity
+
+echo
+echo "#### Testing [sqlite] rse repos from topics"""
+runTest 0 $output rse --config_file $config/rse.ini topics --search singularity
 
 echo
 echo "#### Testing [sqlite] rse add (bulk)"""


### PR DESCRIPTION
This is the first round of changes for a PR to hugely improve the interface. Namely, I'd like to have a simple main screen where a user can search or view the encyclopedia based on topics. We need to add topics to the data and be able to query them first (this pull request).

Signed-off-by: vsoch <vsochat@stanford.edu>