### PR TITLE
Add ropensci scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.0.x](https://github.com/rseng/rse/tree/master) (0.0.x)
+ - adding ropensci scraper (0.0.34)
  - updating local index to be a data table (0.0.33)
  - move repository link to be part of card (0.0.32)
  - ipython should not be required for shell (0.0.31)

--- a/docs/_docs/getting-started/scrapers.md
+++ b/docs/_docs/getting-started/scrapers.md
@@ -33,6 +33,7 @@ and it includes links to repositories:
  - [bio.tools](#biotools)
  - [Hal Research Software Database](#hal)
  - [Research Software NL Dictionary](#researchsoftwarenl)
+ - [ROpenSci](#ropensci)
 
 
 <a id="joss">
@@ -234,4 +235,35 @@ scraper = get_named_scraper('rsnl')
 ```python
 from rse.main.scrapers import RSNLScraper
 scraper = RSNLScraper()
+```
+
+
+<a id="ropensci">
+### ROpenSci
+
+The [ROpenSci](https://github.com/ropensci/) GitHub organization includes peer
+reviewed software that renders to [https://docs.ropensci.org](https://docs.ropensci.org).
+The way we determine if a repository is a code repository is by way of the description
+URL being filled in to have that prefix.
+
+```bash
+$ rse scrape ropensci
+```
+
+To do a dry run:
+
+```bash
+$ rse scrape --dry-run ropensci
+```
+
+The [within python](#within-python) interaction is the same, except you need to
+select the ropensci named parser.
+
+```python
+from rse.main.scrapers import get_named_scraper
+scraper = get_named_scraper('ropensci')
+```
+```python
+from rse.main.scrapers import ROpenSciScraper
+scraper = ROpenSciScraper()
 ```

--- a/docs/_docs/getting-started/scrapers.md
+++ b/docs/_docs/getting-started/scrapers.md
@@ -243,8 +243,17 @@ scraper = RSNLScraper()
 
 The [ROpenSci](https://github.com/ropensci/) GitHub organization includes peer
 reviewed software that renders to [https://docs.ropensci.org](https://docs.ropensci.org).
-The way we determine if a repository is a code repository is by way of the description
-URL being filled in to have that prefix.
+We do this by way of parsing the ROpenSci GitHub repository (e.g., to get the latest
+or full listing) and also comparing this to the [registry.json](https://github.com/ropensci/roregistry/blob/gh-pages/registry.json)
+file. This means that we:
+
+1. Start with the GitHub repository listing, and skip over any repos not in the registry.
+2. We update the metadata with topics and description (if not defined) from the registry.
+3. In the case of a full parsing (not looking for latest) we add any names from the registry not seen in GitHub (e.g., repositories in other organizations)
+4. In the case of a "latest" parsing we do not consider this list.
+
+This seems to do a fairly good job of capturing the bulk of ROpenSci repos!
+The "latest" scrape looks like this:
 
 ```bash
 $ rse scrape ropensci

--- a/rse/app/templates/topics/index.html
+++ b/rse/app/templates/topics/index.html
@@ -29,8 +29,8 @@
         <tr>
             <th>Repository</th>
             <th>Description</th>
-            <th>✏️ Taxonomy</th>
             <th>✏️ Criteria</th>
+            <th>✏️ Taxonomy</th>
             <th>Topics</th>
         </tr>
   </thead>      

--- a/rse/client/scrape.py
+++ b/rse/client/scrape.py
@@ -20,10 +20,10 @@ def main(args, extra):
         sys.exit(f"{args.scraper_name[0]} is not a known scraper.")
 
     # Either get latest entries, or based on search
-    # if args.query is not None:
-    results = scraper.search(args.query, delay=args.delay)
-    # else:
-    #    results = scraper.latest(delay=args.delay)
+    if args.query is not None:
+        results = scraper.search(args.query, delay=args.delay)
+    else:
+        results = scraper.latest(delay=args.delay)
     print("Found %s results" % len(results))
 
     # If we have results and it's not a dry run, create the repos

--- a/rse/client/scrape.py
+++ b/rse/client/scrape.py
@@ -20,10 +20,10 @@ def main(args, extra):
         sys.exit(f"{args.scraper_name[0]} is not a known scraper.")
 
     # Either get latest entries, or based on search
-    if args.query is not None:
-        results = scraper.search(args.query, delay=args.delay)
-    else:
-        results = scraper.latest(delay=args.delay)
+    # if args.query is not None:
+    results = scraper.search(args.query, delay=args.delay)
+    # else:
+    #    results = scraper.latest(delay=args.delay)
     print("Found %s results" % len(results))
 
     # If we have results and it's not a dry run, create the repos

--- a/rse/client/shell.py
+++ b/rse/client/shell.py
@@ -10,7 +10,6 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 from rse.main import Encyclopedia
 from rse.defaults import RSE_SHELL
-import sys
 
 
 def main(args, extra):

--- a/rse/client/topics.py
+++ b/rse/client/topics.py
@@ -9,7 +9,6 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
 
 from rse.main import Encyclopedia
-from rse.logger import bot
 
 
 def main(args, extra):

--- a/rse/main/__init__.py
+++ b/rse/main/__init__.py
@@ -127,10 +127,10 @@ class Encyclopedia:
                     pass
         return repos
 
-    def add(self, uid, quiet=False):
+    def add(self, uid, quiet=False, data=None):
         """A wrapper to add a repository to the software database."""
         if not self.exists(uid):
-            repo = self.db.add(uid)
+            repo = self.db.add(uid, data)
             return repo
         if not quiet:
             bot.error(f"{uid} already exists in the database.")

--- a/rse/main/__init__.py
+++ b/rse/main/__init__.py
@@ -130,7 +130,7 @@ class Encyclopedia:
     def add(self, uid, quiet=False, data=None):
         """A wrapper to add a repository to the software database."""
         if not self.exists(uid):
-            repo = self.db.add(uid, data)
+            repo = self.db.add(uid, data=data)
             return repo
         if not quiet:
             bot.error(f"{uid} already exists in the database.")

--- a/rse/main/database/filesystem.py
+++ b/rse/main/database/filesystem.py
@@ -77,11 +77,12 @@ class FileSystemDatabase(Database):
         except:
             return False
 
-    def add(self, uid):
+    def add(self, uid, data=None):
         """Add a new software repository to the database."""
         if uid:
             parser = get_parser(uid, config=self.config)
-            data = parser.get_metadata()
+            if not data:
+                data = parser.get_metadata()
 
             # If it's a parser handoff
             if isinstance(data, ParserBase):

--- a/rse/main/database/filesystem.py
+++ b/rse/main/database/filesystem.py
@@ -81,8 +81,11 @@ class FileSystemDatabase(Database):
         """Add a new software repository to the database."""
         if uid:
             parser = get_parser(uid, config=self.config)
+
             if not data:
                 data = parser.get_metadata()
+            else:
+                parser.data = data
 
             # If it's a parser handoff
             if isinstance(data, ParserBase):

--- a/rse/main/database/relational.py
+++ b/rse/main/database/relational.py
@@ -97,13 +97,15 @@ class RelationalDatabase(Database):
 
     # Add or Update requires executor
 
-    def add(self, uid):
+    def add(self, uid, data=None):
         """Create a new repo based on a uid that matches to a parser."""
         from rse.main.database.models import SoftwareRepository
 
         parser = get_parser(uid, config=self.config)
         if not self.exists(parser.uid):
-            data = parser.get_metadata()
+
+            if not data:
+                data = parser.get_metadata()
 
             # If it's a parser handoff
             if isinstance(data, ParserBase):

--- a/rse/main/database/relational.py
+++ b/rse/main/database/relational.py
@@ -106,6 +106,8 @@ class RelationalDatabase(Database):
 
             if not data:
                 data = parser.get_metadata()
+            else:
+                parser.data = data
 
             # If it's a parser handoff
             if isinstance(data, ParserBase):

--- a/rse/main/parsers/github.py
+++ b/rse/main/parsers/github.py
@@ -12,8 +12,7 @@ import logging
 import random
 import requests
 from time import sleep
-from rse.utils.urls import check_response
-from rse.utils.urls import get_user_agent, check_response, repository_regex
+from rse.utils.urls import get_user_agent, check_response
 
 from .base import ParserBase
 

--- a/rse/main/parsers/github.py
+++ b/rse/main/parsers/github.py
@@ -159,9 +159,15 @@ class GitHubParser(ParserBase):
         url = "%s/topics" % repo["url"]
         response = requests.get(url, headers=headers)
 
-        # Successful query!
+        # Add topics on successful query
         topics = check_response(response)
         if topics is not None:
             data["topics"] = topics.get("names", [])
+
+        # Add topics from another source
+        if "topics" not in data and "topics" in repo:
+            data["topics"] = repo["topics"]
+        elif "topics" in data and "topics" in repo:
+            data["topics"] += [x for x in repo["topics"] if x not in data["topics"]]
 
         return data

--- a/rse/main/scrapers/__init__.py
+++ b/rse/main/scrapers/__init__.py
@@ -12,6 +12,7 @@ from .biotools import BioToolsScraper
 from .hal import HalScraper
 from .joss import JossScraper
 from .rsnl import RSNLScraper
+from .ropensci import ROpenSciScraper
 import re
 
 
@@ -26,6 +27,8 @@ def get_named_scraper(name, config=None):
         scraper = HalScraper()
     elif re.search("(researchsoftwarenl|rsnl)", name, re.IGNORECASE):
         scraper = RSNLScraper()
+    elif re.search("ropensci", name, re.IGNORECASE):
+        scraper = ROpenSciScraper()
 
     if not scraper:
         raise NotImplementedError(f"There is no matching scraper for {name}")

--- a/rse/main/scrapers/ropensci.py
+++ b/rse/main/scrapers/ropensci.py
@@ -8,13 +8,8 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-from rse.utils.urls import get_user_agent, check_response, repository_regex
-from rse.main.parsers import get_parser, GitHubParser
+from rse.main.parsers import GitHubParser
 import logging
-import requests
-import random
-import re
-from time import sleep
 
 from .base import ScraperBase
 

--- a/rse/main/scrapers/ropensci.py
+++ b/rse/main/scrapers/ropensci.py
@@ -1,0 +1,79 @@
+"""
+
+Copyright (C) 2022 Vanessa Sochat.
+
+This Source Code Form is subject to the terms of the
+Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
+with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+
+from rse.utils.urls import get_user_agent, check_response, repository_regex
+from rse.main.parsers import get_parser, GitHubParser
+import logging
+import requests
+import random
+import re
+from time import sleep
+
+from .base import ScraperBase
+
+bot = logging.getLogger("rse.main.scrapers.ropensci")
+
+
+class ROpenSciScraper(ScraperBase):
+
+    name = "ropensci"
+
+    def __init__(self, query=None, **kwargs):
+        super().__init__(query)
+
+    def latest(self, paginate=False, delay=0.0):
+        """
+        Only return latest (top page) of results (default is sort by created)
+        """
+        return self.scrape(paginate=paginate, delay=delay)
+
+    def search(self, query=None, paginate=True, delay=0.0):
+        """
+        Return all paginated results with search (no query accepted for now)
+        """
+        return self.scrape(paginate=paginate, delay=delay)
+
+    def scrape(self, paginate=False, delay=None):
+        """A shared function to scrape a set of repositories. Since the JoSS
+        pages for a search and the base are the same, we can use a shared
+        function.
+        """
+        parser = GitHubParser()
+        repos = parser.get_org_repos("ropensci", paginate=paginate, delay=delay)
+
+        results = []
+        for entry in repos:
+
+            if not entry:
+                continue
+
+            # We determine software release based on the homepage url
+            homepage = entry.get("homepage", "")
+            if not homepage or "https://docs.ropensci.org" not in homepage:
+                bot.info("Skipping repository: %s" % entry["html_url"])
+                continue
+            bot.info("Found repository: %s" % entry["html_url"])
+            self.results.append(parser.parse_github_repo(entry))
+        return self.results
+
+    def create(self, database=None, config_file=None):
+        """After a scrape (whether we obtain latest or a search query) we
+        run create to create software repositories based on results.
+        """
+        from rse.main import Encyclopedia
+
+        client = Encyclopedia(config_file=config_file, database=database)
+        for result in self.results:
+            uid = result["html_url"].split("//")[-1]
+
+            # Add results that don't exist
+            if not client.exists(uid):
+                client.add(uid, data=result)
+                name = os.path.basename(uid)

--- a/rse/main/scrapers/ropensci.py
+++ b/rse/main/scrapers/ropensci.py
@@ -48,7 +48,6 @@ class ROpenSciScraper(ScraperBase):
         parser = GitHubParser()
         repos = parser.get_org_repos("ropensci", paginate=paginate, delay=delay)
 
-        results = []
         for entry in repos:
 
             if not entry:
@@ -76,4 +75,3 @@ class ROpenSciScraper(ScraperBase):
             # Add results that don't exist
             if not client.exists(uid):
                 client.add(uid, data=result)
-                name = os.path.basename(uid)

--- a/rse/version.py
+++ b/rse/version.py
@@ -10,7 +10,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 __version__ = "0.0.34"
 AUTHOR = "Vanessa Sochat"
-AUTHOR_EMAIL = "vsochat@stanford.edu"
+AUTHOR_EMAIL = "vsoch@users.noreply.github.io"
 NAME = "rse"
 PACKAGE_URL = "https://github.com/rseng/rse"
 KEYWORDS = "rse,software,research software,database,taxonomy"

--- a/rse/version.py
+++ b/rse/version.py
@@ -8,7 +8,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
 
-__version__ = "0.0.33"
+__version__ = "0.0.34"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsochat@stanford.edu"
 NAME = "rse"

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-Copyright (C) 2020 Vanessa Sochat.
+Copyright (C) 2020-2022 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/tests/test_parser_github.py
+++ b/tests/test_parser_github.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-Copyright (C) 2020 Vanessa Sochat.
+Copyright (C) 2020-2022 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed
@@ -32,3 +32,10 @@ def test_parser_github(tmp_path):
     data = parser.export()
     for key in ["timestamp", "url", "html_url"]:
         assert key in data
+        
+def test_org_repos(tmp_path):
+    """Test the github parser to retrieve org repos."""
+    from rse.main.parsers import GitHubParser
+    parser = GitHubParser()
+    data = parser.get_org_repos("ropensci", paginate=False)
+    assert len(data) == 100

--- a/tests/test_parser_gitlab.py
+++ b/tests/test_parser_gitlab.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-Copyright (C) 2020 Vanessa Sochat.
+Copyright (C) 2020-2022 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed

--- a/tests/test_parser_zenodo.py
+++ b/tests/test_parser_zenodo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
 
-Copyright (C) 2020 Vanessa Sochat.
+Copyright (C) 2020-2022 Vanessa Sochat.
 
 This Source Code Form is subject to the terms of the
 Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed


### PR DESCRIPTION
This will add a scraper to parse ROpenSci repos! We determine a software repo is one based on it having a homepage (the link in the description) to a docs page on the ropensci docs site. This means we likely have a few false negatives if there is a repo that should have this URL but does not, but we are less likely to have false positives.