### PR TITLE
Fix typo `RSE_GITHUB_TOKEN` -> `RSE_GITLAB_TOKEN` in parsers.md

### DIFF
--- a/docs/_docs/getting-started/parsers.md
+++ b/docs/_docs/getting-started/parsers.md
@@ -288,7 +288,7 @@ parser.uid
 ```
 
 Once the identifier is loaded, you can parse updated metadata for it.
-Note that this requires a `RSE_GITHUB_TOKEN` to be set in the environment.
+Note that this requires a `RSE_GITLAB_TOKEN` to be set in the environment.
 You can then get the repository-level metadata about the software repository:
 
 ```python


### PR DESCRIPTION
Just a very minor typo fix