### PR TITLE
allowing csv export to use custom parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip.
 
 ## [0.0.x](https://github.com/rseng/rse/tree/master) (0.0.x)
+ - allow custom import for csv and google-sheet (0.0.47)
  - support for csv import (0.0.46)
  - ensure Google scraper skips malformed rows, etc (0.0.45)
  - Logging bugs and adding export/import docs (0.0.44)

--- a/rse/main/scrapers/csv.py
+++ b/rse/main/scrapers/csv.py
@@ -107,25 +107,22 @@ class CSVImporter(ScraperBase):
             uid = result["url"].split("//")[-1]
 
             # If a repository is added that isn't represented
-            try:
-                repo = get_parser(uid)
-                data = repo.get_metadata()
+            repo = get_parser(uid)
+            data = repo.get_metadata() or {}
 
-                # Empty or malformed repository
-                if not data:
-                    bot.warning(f"Skipping malformed entry {uid}")
-                    continue
-                result = update_nonempty(result, data)
-
-            # Or as custom entry
-            except NotImplementedError:
-                # Base UID based on title
+            # Empty or malformed repository
+            if not data and repo.name == "custom":
                 repo = CustomParser(result["title"])
                 repo.set_metadata(
                     title=result["title"],
                     url=result["url"],
                     description=result["description"],
                 )
+
+            elif not data:
+                bot.warning(f"Skipping malformed entry {uid}")
+                continue
+            result = update_nonempty(result, data)
 
             # Add results that don't exist
             exists = client.exists(repo.uid)

--- a/rse/version.py
+++ b/rse/version.py
@@ -9,7 +9,7 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """
 
 
-__version__ = "0.0.46"
+__version__ = "0.0.47"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.io"
 NAME = "rse"


### PR DESCRIPTION
@NickleDave here are fixes so the custom parser is re-enabled - I think what happened is I made it default for get_parser (before it would throw an exception to not be GitHub, etc) and that meant the logic needed to be changed to check the parser name and data (empty or not) to determine assembling the custom repository. I think I've fixed it here, and I've also fixed your data file so there aren't any erroneous imports, attached.

Let me know if this works for you!

- This will close #82 

[copy-Bioacoustics-software.csv](https://github.com/rseng/rse/files/9630136/copy-Bioacoustics-software.csv)

Signed-off-by: vsoch <vsoch@users.noreply.github.com>